### PR TITLE
fix: replace deprecated flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - /app/node_modules
     ports:
       - '7777:7777'
-    links:
+    depends_on:
       - mongo
 
   mongo:


### PR DESCRIPTION
--links flag is deprecated and may be removed in the near future.
Replace it with --depends_on.

Read more:

https://docs.docker.com/compose/compose-file/#links